### PR TITLE
Vcs provider client optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ FEATURES:
 ENHANCEMENTS:
 
 BUG FIXES:
+* `r/tfe_workspace`: Set attribute `oauth_token_id` and `github_app_installation_id` on `vcs_repo` only if configured, by @ishashchuk ([#875](https://github.com/hashicorp/terraform-provider-tfe/pull/875))
+* `r/tfe_policy_set`: Set attribute `oauth_token_id` and `github_app_installation_id` on `vcs_repo` only if configured, by @ishashchuk ([#875](https://github.com/hashicorp/terraform-provider-tfe/pull/875))
+* `r/tfe_registry_module`: Set attribute `oauth_token_id` and `github_app_installation_id` on `vcs_repo` only if configured, by @ishashchuk ([#875](https://github.com/hashicorp/terraform-provider-tfe/pull/875))
 
 ## v0.44.1 (April 21, 2023)
 

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -354,9 +354,8 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 				Identifier:        tfe.String(vcsRepo["identifier"].(string)),
 				Branch:            tfe.String(vcsRepo["branch"].(string)),
 				IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
-				OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-				GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
 			}
+
 			// Only set the oauth_token_id if it is configured.
 			if oauthTokenID, ok := vcsRepo["oauth_token_id"].(string); ok && oauthTokenID != "" {
 				options.VCSRepo.OAuthTokenID = tfe.String(oauthTokenID)

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -183,14 +183,23 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 		options.VCSRepo = &tfe.VCSRepoOptions{
 			Identifier:        tfe.String(vcsRepo["identifier"].(string)),
 			IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
-			OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-			GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
 		}
 
 		// Only set the branch if one is configured.
 		if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
 			options.VCSRepo.Branch = tfe.String(branch)
 		}
+
+		// Only set the oauth_token_id if it is configured.
+		if oauthTokenID, ok := vcsRepo["oauth_token_id"].(string); ok && oauthTokenID != "" {
+			options.VCSRepo.OAuthTokenID = tfe.String(oauthTokenID)
+		}
+
+		// Only set the github_app_installation_id if it is configured.
+		if ghaInstallationID, ok := vcsRepo["github_app_installation_id"].(string); ok && ghaInstallationID != "" {
+			options.VCSRepo.GHAInstallationID = tfe.String(ghaInstallationID)
+		}
+
 	}
 
 	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {
@@ -348,6 +357,15 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 				IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
 				OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
 				GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
+			}
+			// Only set the oauth_token_id if it is configured.
+			if oauthTokenID, ok := vcsRepo["oauth_token_id"].(string); ok && oauthTokenID != "" {
+				options.VCSRepo.OAuthTokenID = tfe.String(oauthTokenID)
+			}
+
+			// Only set the github_app_installation_id if it is configured.
+			if ghaInstallationID, ok := vcsRepo["github_app_installation_id"].(string); ok && ghaInstallationID != "" {
+				options.VCSRepo.GHAInstallationID = tfe.String(ghaInstallationID)
 			}
 		}
 

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -199,7 +199,6 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 		if ghaInstallationID, ok := vcsRepo["github_app_installation_id"].(string); ok && ghaInstallationID != "" {
 			options.VCSRepo.GHAInstallationID = tfe.String(ghaInstallationID)
 		}
-
 	}
 
 	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {

--- a/tfe/resource_tfe_registry_module.go
+++ b/tfe/resource_tfe_registry_module.go
@@ -115,8 +115,8 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}) (*t
 	vcsRepo := v.([]interface{})[0].(map[string]interface{})
 
 	options.VCSRepo = &tfe.RegistryModuleVCSRepoOptions{
-		Identifier:        tfe.String(vcsRepo["identifier"].(string)),
-		OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
+		Identifier:   tfe.String(vcsRepo["identifier"].(string)),
+		OAuthTokenID: tfe.String(vcsRepo["oauth_token_id"].(string)),
 	}
 
 	// Only set the oauth_token_id if it is configured.

--- a/tfe/resource_tfe_registry_module.go
+++ b/tfe/resource_tfe_registry_module.go
@@ -115,8 +115,8 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}) (*t
 	vcsRepo := v.([]interface{})[0].(map[string]interface{})
 
 	options.VCSRepo = &tfe.RegistryModuleVCSRepoOptions{
-		Identifier:   tfe.String(vcsRepo["identifier"].(string)),
-		OAuthTokenID: tfe.String(vcsRepo["oauth_token_id"].(string)),
+		Identifier:        tfe.String(vcsRepo["identifier"].(string)),
+		DisplayIdentifier: tfe.String(vcsRepo["display_identifier"].(string)),
 	}
 
 	// Only set the oauth_token_id if it is configured.

--- a/tfe/resource_tfe_registry_module.go
+++ b/tfe/resource_tfe_registry_module.go
@@ -117,8 +117,16 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}) (*t
 	options.VCSRepo = &tfe.RegistryModuleVCSRepoOptions{
 		Identifier:        tfe.String(vcsRepo["identifier"].(string)),
 		OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-		GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
-		DisplayIdentifier: tfe.String(vcsRepo["display_identifier"].(string)),
+	}
+
+	// Only set the oauth_token_id if it is configured.
+	if oauthTokenID, ok := vcsRepo["oauth_token_id"].(string); ok && oauthTokenID != "" {
+		options.VCSRepo.OAuthTokenID = tfe.String(oauthTokenID)
+	}
+
+	// Only set the github_app_installation_id if it is configured.
+	if ghaInstallationID, ok := vcsRepo["github_app_installation_id"].(string); ok && ghaInstallationID != "" {
+		options.VCSRepo.GHAInstallationID = tfe.String(ghaInstallationID)
 	}
 
 	log.Printf("[DEBUG] Create registry module from repository %s", *options.VCSRepo.Identifier)

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -624,9 +624,16 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 				Identifier:        tfe.String(vcsRepo["identifier"].(string)),
 				Branch:            tfe.String(vcsRepo["branch"].(string)),
 				IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
-				OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-				GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
 				TagsRegex:         tfe.String(vcsRepo["tags_regex"].(string)),
+			}
+			// Only set the oauth_token_id if it is configured.
+			if oauthTokenID, ok := vcsRepo["oauth_token_id"].(string); ok && oauthTokenID != "" {
+				options.VCSRepo.OAuthTokenID = tfe.String(oauthTokenID)
+			}
+
+			// Only set the github_app_installation_id if it is configured.
+			if ghaInstallationID, ok := vcsRepo["github_app_installation_id"].(string); ok && ghaInstallationID != "" {
+				options.VCSRepo.GHAInstallationID = tfe.String(ghaInstallationID)
 			}
 		}
 


### PR DESCRIPTION
## Description

Address https://github.com/hashicorp/terraform-provider-tfe/issues/834 - only set oauth_token_id and github_app_installation_id if configured. Before this change, they'd be set to an empty string, resulting in failed applies in on creates and updated for the affected resources.

This is a follow up to a PR https://github.com/hashicorp/terraform-provider-tfe/pull/835  that partially fixed the issue above. The PR only fixed tfe_workspace CREATE functionality. But Github App support on all resource changes rolled out in original PR https://github.com/hashicorp/terraform-provider-tfe/pull/808 are affected with the same issue. 

This PR is fixing:
- tfe_policy_set CREATE and UPDATE.
- tfe_workspace UPDATE
- tfe_module_registry

_Remember to:_

- [X] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

- [X] No documentation changes needed

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- Related PR where the failty functionality was first introduced: https://github.com/hashicorp/terraform-provider-tfe/pull/808
- Original Issue filed describing the issue: https://github.com/hashicorp/terraform-provider-tfe/issues/834
- PR partially fixing the issue https://github.com/hashicorp/terraform-provider-tfe/pull/835

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
